### PR TITLE
Don't cancel already finished tasks

### DIFF
--- a/sequence.ts
+++ b/sequence.ts
@@ -27,7 +27,7 @@ namespace story {
 
         cancelByKey(key: string) {
             for (const task of this.activeTasks) {
-                if (task.key === key && task.cancel) {
+                if (task.key === key && task.cancel && !task.isDone()) {
                     task.cancel();
                     return;
                 }
@@ -37,7 +37,7 @@ namespace story {
         clear() {
             this.queue = [];
             for (const task of this.activeTasks) {
-                if (task.cancel)
+                if (task.cancel && !task.isDone())
                     task.cancel();
             }
             this.reset();
@@ -115,7 +115,7 @@ namespace story {
             const state = stateStack[stateStack.length - 1];
             state.clearFinishedTasks();
             if (state.lock) return;
-            
+
             if (state.queue.length) {
                 if (state.shouldAdvance() || !state.running) {
                     if (state.running) {


### PR DESCRIPTION
Finally fixing that movement bug in the story extension where you sometimes teleport. The previous task was getting cancelled after it finished causing the sprite's velocity to be set to 0.

Thanks to @UnsignedArduino for finally motivating me to fix this.